### PR TITLE
support scons 3 as well as scons 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ os:
   - osx
 
 env:
-  global:
-    - MYPYTHON_VERSION=2.7
-  matrix:
-    - MYUSEMC=true
-    - MYUSEMC=false
+  - MYUSEMC=true MYPYTHON_VERSION=2.7
+  - MYUSEMC=true MYPYTHON_VERSION=3.5
+  - MYUSEMC=true MYPYTHON_VERSION=3.6
+  - MYUSEMC=false
 
 git:
   depth: 999999
@@ -78,8 +77,8 @@ before_install:
 
 
 install:
-  - $NOMC || conda build conda-recipe
-  - $NOMC || conda render --output conda-recipe |
+  - $NOMC || conda build --python=${MYPYTHON_VERSION} conda-recipe
+  - $NOMC || conda render --python=${MYPYTHON_VERSION} --output conda-recipe |
                 sed 's,.*/,,; s/[.]tar[.]bz2$//; s/-/=/g' > /tmp/mypackage.txt
   - $NOMC || source activate testenv
   - $NOMC || conda install --yes --use-local --file=/tmp/mypackage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ install:
                 sed 's,.*/,,; s/[.]tar[.]bz2$//; s/-/=/g' > /tmp/mypackage.txt
   - $NOMC || source activate testenv
   - $NOMC || conda install --yes --use-local --file=/tmp/mypackage.txt
-  - $NOMC || conda install --yes scons
   - $NOMC || MYPREFIX="${HOME}/mc/envs/testenv"
 
   - MYSUDO=

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,11 +107,6 @@ install:
   - $NOMC || export CPATH="${MYINCLUDE}"
   - $NOMC || MYLINKFLAGS="-Wl,-rpath,${MYLIB}"
 
-  # Mac OS X must use the same deployment target as conda-build.
-  - if $MYUSEMC && [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-        export MACOSX_DEPLOYMENT_TARGET=10.7;
-    fi
-
 
 before_script:
   - cd "${TRAVIS_BUILD_DIR}/examples"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ c++ testlib.cpp -I$P/include -L$P/lib -Wl,-rpath,$P/lib -lObjCryst
 ```
 
 On Mac OS X the Anaconda libobjcryst is built for OS X version
-10.7 which may be incompatible with codes compiled on newer OS.
-To fix this pass `-mmacosx-version-min=10.7` option to the
+10.9 which may be incompatible with codes compiled on newer OS.
+To fix this pass `-mmacosx-version-min=10.9` option to the
 c++ compiler or set it with an environment variable as
-`export MACOSX_DEPLOYMENT_TARGET=10.7`.
+`export MACOSX_DEPLOYMENT_TARGET=10.9`.

--- a/SConstruct
+++ b/SConstruct
@@ -20,7 +20,7 @@ import os
 import platform
 
 def subdictionary(d, keyset):
-    return dict([kv for kv in d.items() if kv[0] in keyset])
+    return dict(kv for kv in d.items() if kv[0] in keyset)
 
 # copy system environment variables related to compilation
 DefaultEnvironment(ENV=subdictionary(os.environ, '''

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,6 +13,7 @@ build:
 
 requirements:
   build:
+    - python
     - scons
     - boost 1.61.0
 

--- a/site_scons/gitarchive.cfg
+++ b/site_scons/gitarchive.cfg
@@ -1,4 +1,3 @@
-[DEFAULT]
 commit = $Format:%H$
 date = $Format:%ai$
 refnames = $Format:%D$

--- a/site_scons/libobjcrystbuildutils.py
+++ b/site_scons/libobjcrystbuildutils.py
@@ -27,7 +27,8 @@ def gitinfo():
     if _cached_gitinfo is not None:
         return _cached_gitinfo
     nullfile = open(os.devnull, 'w')
-    kw = dict(stdout=PIPE, stderr=nullfile, cwd=MYDIR)
+    kw = dict(stdout=PIPE, stderr=nullfile, cwd=MYDIR,
+              universal_newlines=True)
     proc = Popen(['git', 'describe', '--match=v[[:digit:]]*'], **kw)
     desc = proc.stdout.read()
     if proc.wait():

--- a/site_scons/libobjcrystbuildutils.py
+++ b/site_scons/libobjcrystbuildutils.py
@@ -57,13 +57,13 @@ def getversion():
     in gitarchive.cfg.  Use expanded data from gitarchive.cfg when
     these sources are from git archive bundle.
     """
-    from ConfigParser import RawConfigParser
     from fallback_version import FALLBACK_VERSION
     gitarchivecfgfile = os.path.join(MYDIR, 'gitarchive.cfg')
     assert os.path.isfile(gitarchivecfgfile)
-    cp = RawConfigParser()
-    cp.read(gitarchivecfgfile)
-    ga = cp.defaults()
+    with open(gitarchivecfgfile) as fp:
+        gacontent = fp.read()
+    gaitems = re.findall(r'^(\w+) *= *(\S.*?)\s*$', gacontent, re.M)
+    ga = dict(gaitems)
     gi = gitinfo()
     rv = {}
     if gi:

--- a/src/SConscript.version
+++ b/src/SConscript.version
@@ -15,7 +15,7 @@ def get_version_or_die():
 
 
 def build_VersionCode(target, source, env):
-    tplcode = source[0].get_contents()
+    tplcode = source[0].get_text_contents()
     numversion = gver['major']
     numversion = 1000 * numversion + gver['minor']
     numversion = 1000 * numversion + gver['micro']
@@ -41,7 +41,8 @@ def build_VersionCode(target, source, env):
     }
     versiontemplate = string.Template(tplcode)
     versioncode = versiontemplate.safe_substitute(flds)
-    open(target[0].path, 'w').write(versioncode)
+    with open(target[0].path, 'w') as fp:
+        fp.write(versioncode)
     return None
 
 env.Append(BUILDERS={'BuildVersionCode' :


### PR DESCRIPTION
- adjust SCons scripts to be Python 2 and Python 3 compatible
- add travis test builds of conda package with scons 3 using Python 3 build environment

Fixes https://github.com/diffpy/libobjcryst/issues/6.