### PR TITLE
Update libobjcryst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release notes
 
+## Version 2021.1.2 - 2021-11-28
+
+### Added
+
+- Add access to the weight (g/mol) for ScatteringPowerAtom and Crystal
+
+### Changed
+
+- Add relative_length_tolerance and absolute_angle_tolerance_degree to 
+  SpaceGroupExplorer::Run() and RunAll()
+- Crystal::XMLInput(): add a hook to re-use atomic scattering power when
+  mDeleteSubObjInDestructor is False
+- Better formula for Crystal and Molecule
+
+### Fixed
+
+- Crystal::XMLInput(): take into account mDeleteSubObjInDestructor.
+
 ## Version 2021.1.1 - 2021-06-04
 
 ### Added

--- a/src/ObjCryst/ObjCryst/Crystal.cpp
+++ b/src/ObjCryst/ObjCryst/Crystal.cpp
@@ -409,12 +409,12 @@ std::string Crystal::GetFormula() const
    {
       if(pos!=velts.begin()) s<<" ";
       float nb=pos->second;
-      if((abs(nb)-nb)<0.01) s<<pos->first<<int(round(nb));
+      if(abs(round(nb)-nb)<0.005) s<<pos->first<<int(round(nb));
       else s<<pos->first<<nb;
    }
    return s.str();
 }
-   
+
 
 REAL Crystal::GetWeight() const
 {

--- a/src/ObjCryst/ObjCryst/Crystal.cpp
+++ b/src/ObjCryst/ObjCryst/Crystal.cpp
@@ -409,7 +409,11 @@ std::string Crystal::GetFormula() const
    {
       if(pos!=velts.begin()) s<<" ";
       float nb=pos->second;
-      if(abs(round(nb)-nb)<0.005) s<<pos->first<<int(round(nb));
+      if(abs(round(nb)-nb)<0.005)
+      {
+         if(int(round(nb))==1) s<<pos->first;
+         else s<<pos->first<<int(round(nb));
+      }
       else s<<pos->first<<nb;
    }
    return s.str();

--- a/src/ObjCryst/ObjCryst/Crystal.cpp
+++ b/src/ObjCryst/ObjCryst/Crystal.cpp
@@ -420,7 +420,7 @@ REAL Crystal::GetWeight() const
 {
    this->GetScatteringComponentList();
    if(mScattCompList.GetNbComponent() == 0) return 0;
-   REAL w;
+   REAL w=0;
    for(unsigned int i=0; i<mScattCompList.GetNbComponent(); ++i)
    {
       const ScatteringComponent* psi = &mScattCompList(i);

--- a/src/ObjCryst/ObjCryst/Crystal.cpp
+++ b/src/ObjCryst/ObjCryst/Crystal.cpp
@@ -381,7 +381,8 @@ void Crystal::Print(ostream &os)const
    for(int i=0;i<mScattCompList.GetNbComponent();i++)
       nbAtoms += genMult * mScattCompList(i).mOccupancy * mScattCompList(i).mDynPopCorr;
    os << " Total number of components (atoms) in one unit cell : " << nbAtoms<<endl
-      << " Chemical formula: "<< this->GetFormula() <<endl;
+      << " Chemical formula: "<< this->GetFormula() << endl
+      << " Weight: "<< this->GetWeight()<< " g/mol" << endl;
 
    VFN_DEBUG_MESSAGE("Crystal::Print():End",5)
 }
@@ -414,6 +415,23 @@ std::string Crystal::GetFormula() const
    return s.str();
 }
    
+
+REAL Crystal::GetWeight() const
+{
+   this->GetScatteringComponentList();
+   if(mScattCompList.GetNbComponent() == 0) return 0;
+   REAL w;
+   for(unsigned int i=0; i<mScattCompList.GetNbComponent(); ++i)
+   {
+      const ScatteringComponent* psi = &mScattCompList(i);
+      if(psi->mpScattPow == 0) continue;
+      if(psi->mpScattPow->GetClassName().compare("ScatteringPowerAtom")!=0) continue;
+      const ScatteringPowerAtom *pat=dynamic_cast<const ScatteringPowerAtom*>(psi->mpScattPow);
+      w += pat->GetAtomicWeight() * psi->mOccupancy * psi->mDynPopCorr ;
+   }
+   return w;
+}
+
 
 CrystMatrix_REAL Crystal::GetMinDistanceTable(const REAL minDistance) const
 {

--- a/src/ObjCryst/ObjCryst/Crystal.h
+++ b/src/ObjCryst/ObjCryst/Crystal.h
@@ -341,19 +341,26 @@ class Crystal:public UnitCell
       const RefinableObjClock& GetClockScattererList()const;
 
       virtual void XMLOutput(ostream &os,int indent=0)const;
+      /** \brief Input the crystal structure from a stream.
+      *
+      * This will destroy any Scatterer of ScatteringPower if
+      * mDeleteSubObjInDestructor is true. Otherwise they will just
+      * be de-registered and should be deleted somewhere else,
+      * but there is a special hook implemented where any
+      * previously existing ScatteringPowerAtom will be re-used if
+      * equivalent to the one in the input.
+      */
       virtual void XMLInput(istream &is,const XMLCrystTag &tag);
       //virtual void XMLInputOld(istream &is,const IOCrystTag &tag);
 
       virtual void GlobalOptRandomMove(const REAL mutationAmplitude,
                                        const RefParType *type=gpRefParTypeObjCryst);
       virtual REAL GetLogLikelihood()const;
-      /** \brief output Crystal structure as a cif file (EXPERIMENTAL !)
+      /** \brief output Crystal structure as a cif file
       *  \param mindist : minimum distance between atoms to consider them
       *  overlapping. Overlapping atoms are only included as comments in the
       *  CIF file.
       *
-      * \warning This is very crude and EXPERIMENTAL so far:  there is not much
-      * information beside atom positions...
       */
       virtual void CIFOutput(ostream &os, double mindist = 0.5)const;
 

--- a/src/ObjCryst/ObjCryst/Crystal.h
+++ b/src/ObjCryst/ObjCryst/Crystal.h
@@ -192,6 +192,9 @@ class Crystal:public UnitCell
    
       /// Formula with atoms in alphabetic order
       std::string GetFormula() const;
+      /// Weight for the crystal formula, in atomic units (g/mol). This should be
+      /// multiplied by the spacegroup multiplity to get the unit cell weight.
+      REAL GetWeight() const;
 
       /** \brief Minimum interatomic distance between all scattering components (atoms) in
       * the crystal.

--- a/src/ObjCryst/ObjCryst/Molecule.cpp
+++ b/src/ObjCryst/ObjCryst/Molecule.cpp
@@ -2207,8 +2207,12 @@ std::string Molecule::GetFormula() const
    {
       if(pos!=velts.begin()) s<<" ";
       float nb=pos->second;
-      if((abs(nb)-nb)<0.01) s<<pos->first<<int(round(nb));
-      else s<<pos->first<<nb;
+      if(abs(round(nb)-nb)<0.005)
+      {
+         if(int(round(nb))==1) s<<pos->first;
+         else s<<pos->first<<int(round(nb));
+      }
+     else s<<pos->first<<nb;
    }
    return s.str();
 }

--- a/src/ObjCryst/ObjCryst/PowderPattern.h
+++ b/src/ObjCryst/ObjCryst/PowderPattern.h
@@ -1211,11 +1211,15 @@ public:
     * \param fitprofile: if true, will perform a full profile fitting instead of just Le Bail
     *  extraction. Much slower.
     * \param restore_orig: if true, will go back to the original unit cell and spacegroup at the end
-    
+    * \param relative_length_tolerance: relative length tolerance to determine compatible unit cells
+    * (i.e. the a/b ratio for quadratic spacegroups)
+    * \param absolute_angle_tolerance_degree: the absolute angular tolerance in degrees
+    * to determine compatible unit cells.
     * \return: the SPGScore corresponding to this spacegroup
     */
    SPGScore Run(const string &spg, const bool fitprofile=false, const bool verbose=false,
-                const bool restore_orig=false, const bool update_display=true);
+                const bool restore_orig=false, const bool update_display=true,
+                const REAL relative_length_tolerance=0.01, const REAL absolute_angle_tolerance_degree=0.5);
    /** Run test on a single spacegroup
     *
     * \param spg: the cctbx::sgtbx::space_group
@@ -1223,10 +1227,15 @@ public:
     *  extraction. Much slower.
     * \param restore_orig: if true, will go back to the original unit cell and spacegroup at the end
     * \param update_display: if true, update the display during the search
+    * \param relative_length_tolerance: relative length tolerance to determine compatible unit cells
+    * (i.e. the a/b ratio for quadratic spacegroups)
+    * \param absolute_angle_tolerance_degree: the absolute angular tolerance in degrees
+    * to determine compatible unit cells.
     * \return: the SPGScore corresponding to this spacegroup
     */
    SPGScore Run(const cctbx::sgtbx::space_group &spg, const bool fitprofile=false,
-                const bool verbose=false, const bool restore_orig=false, const bool update_display=true);
+                const bool verbose=false, const bool restore_orig=false, const bool update_display=true,
+                const REAL relative_length_tolerance=0.01, const REAL absolute_angle_tolerance_degree=0.5);
    /** Run test on all spacegroups compatible with the unit cell
     * Note that all scores's ngof values will be multiplied by nb_refl/nb_refl_P1 to
     * have a better indicator of the quality taking into account the number of reflections used.
@@ -1238,10 +1247,15 @@ public:
     * \param keep_best: if true, will keep the best solution at the end (default: restore the original one)
     * \param update_display: if true, update the display during the search
     * \param fitprofile_p1: if true, fit the profile for p1 (ignored if fitprofile_all=true)
+    * \param relative_length_tolerance: relative length tolerance to determine compatible unit cells
+    * (i.e. the a/b ratio for quadratic spacegroups)
+    * \param absolute_angle_tolerance_degree: the absolute angular tolerance in degrees
+    * to determine compatible unit cells.
     * \return: the SPGScore corresponding to this spacegroup
     */
    void RunAll(const bool fitprofile_all=false, const bool verbose=true, const bool keep_best=false,
-               const bool update_display=true, const bool fitprofile_p1=true);
+               const bool update_display=true, const bool fitprofile_p1=true,
+               const REAL relative_length_tolerance=0.01, const REAL absolute_angle_tolerance_degree=0.5);
    /// Get the list of all scores obatined after using RunAll()
    const list<SPGScore>& GetScores() const;
 private:

--- a/src/ObjCryst/ObjCryst/ScatteringPower.cpp
+++ b/src/ObjCryst/ObjCryst/ScatteringPower.cpp
@@ -366,6 +366,7 @@ void ScatteringPowerAtom::Init(const string &name,const string &symbol,const REA
 
       cctbx::eltbx::tiny_pse::table tpse(mSymbol);
       mAtomicNumber=tpse.atomic_number();
+      mAtomicWeight=tpse.weight();
 
       cctbx::eltbx::icsd_radii::table ticsd(mSymbol);
       mRadius= ticsd.radius();
@@ -781,6 +782,7 @@ string ScatteringPowerAtom::GetElementName() const
 }
 
 int ScatteringPowerAtom::GetAtomicNumber() const {return mAtomicNumber;}
+REAL ScatteringPowerAtom::GetAtomicWeight() const {return mAtomicWeight;}
 REAL ScatteringPowerAtom::GetRadius() const {return mRadius;}
 REAL ScatteringPowerAtom::GetCovalentRadius() const {return mCovalentRadius;}
 unsigned int ScatteringPowerAtom::GetMaxCovBonds()const{ return mMaxCovBonds;}

--- a/src/ObjCryst/ObjCryst/ScatteringPower.h
+++ b/src/ObjCryst/ObjCryst/ScatteringPower.h
@@ -381,8 +381,10 @@ class ScatteringPowerAtom:virtual public ScatteringPower
       *which uses data from the CRC Handbook of Chemistry & Physics, 63rd & 70th editions
       */
       string GetElementName() const;
-      ///Atomic number for this atom
+      /// Atomic number for this atom
       int GetAtomicNumber() const;
+      /// Atomic weight (g/mol) for this atom
+      REAL GetAtomicWeight() const;
       /// Atomic radius for this atom or ion, in Angstroems (ICSD table from cctbx)
       REAL GetRadius() const;
       /// Covalent Radius for this atom, in Angstroems (from cctbx)
@@ -412,6 +414,8 @@ class ScatteringPowerAtom:virtual public ScatteringPower
       string mSymbol;
       /// atomic number (Z) for the atom
       int mAtomicNumber;
+      /// atomic weight (g/mol) for the atom
+      REAL mAtomicWeight;
 
       /** Pointer to cctbx's gaussian describing the thomson x-ray
       * scattering factor.


### PR DESCRIPTION
This PR:
- gives access to the weight (g/mol) for ScatteringPowerAtom and Crystal
- avoids crashes when using Crystal::XMLInput(...) when the crystal is not empty, and re-uses the scattering pwoer when possible
- Small correction to GetFormula for Crystal and Molecule

Associated pyobjcryst PR to come.