### PR TITLE
Update objcryst version for 2026.1, exposing SetPowderPatternObsSigma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 2026.1.1,  - 2026-02-05
+## Version 2026.1,  - 2026-02-05
 
 ### Changed
 - changed boost version to 1.88, switch to c++-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release notes
 
-## Version 2026.1.1,  - 2026-01-xx
+## Version 2026.1.1,  - 2026-02-05
 
 ### Changed
 - changed boost version to 1.88, switch to c++-14
+- update objcryst to include PowderPattern::SetPowderPatternObsSigma
 
 ## Version 2024.2.1,  - 2024-09-09
 

--- a/site_scons/fallback_version.py
+++ b/site_scons/fallback_version.py
@@ -7,4 +7,4 @@ not available for example, when building from git zip archive.
 Update FALLBACK_VERSION when tagging a new release.
 '''
 
-FALLBACK_VERSION = '2024.2.1.post0'
+FALLBACK_VERSION = '2026.1.post0'


### PR DESCRIPTION
Note: unless I'm wrong, `libobjcryst` does not use the same commit hooks which use `news/...` files automatically ?

This is needed for a new release and https://github.com/diffpy/pyobjcryst/pull/84.