### PR TITLE
fix: point objcryst to the fixed spelling version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 2026.1.1, - 2026-08-06
+
+### Fixed
+- Updated ObjCryst++ to provide the correctly spelled `ORTHORHOMBIC`
+  crystal-system enum while retaining `ORTHOROMBIC` as a backward-compatible
+  alias.
+
 ## Version 2026.1,  - 2026-02-05
 
 ### Changed


### PR DESCRIPTION
@sbillinge @vincefn ready to review. In this PR, we point `objcryst` with the latest version for corrected spelling of `ORTHORHOMBIC`. We do this because we need to fix the `pyobjcryst` misspelling issue as referenced here:https://github.com/diffpy/pyobjcryst/pull/97
The next move is to release a new version of `libobjcryst` if this PR could pass.