### PR TITLE
Sync objcryst upstream and add standalone unit-test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,12 @@ jobs:
             os: ubuntu-latest
             arch: x64
             make_cmd: make
-            lib_path: ../build/x86_64-conda-linux-gnu-x86_64/libObjCryst.so
+            lib_path: ../build/fast-x86_64/libObjCryst.so
           - label: macos-arm64
             os: macos-14
             arch: arm64
             make_cmd: gmake
-            lib_path: ../build/arm64-apple-darwin20.0.0-arm64/libObjCryst.dylib
+            lib_path: ../build/fast-arm64/libObjCryst.dylib
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     name: ${{ matrix.label }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build libobjcryst
         shell: bash -el {0}
         run: |
-          PREFIX="$CONDA_PREFIX" python -m SCons -Q lib
+          PREFIX="$CONDA_PREFIX" python -m SCons -Q lib VERSION=2026.2
 
       - name: Run standalone unit tests
         shell: bash -el {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -58,10 +58,19 @@ jobs:
         run: |
           python - <<'PY'
           from pathlib import Path
-          p = Path("site_scons/fallback_version.py")
+          p = Path("site_scons/libobjcrystbuildutils.py")
           txt = p.read_text()
-          txt = txt.replace("FALLBACK_VERSION = '2026.2.post0'",
-                            "FALLBACK_VERSION = '2026.1.post0'")
+          old = """        afb = FALLBACK_VERSION
+        gfb = gi['version'].split('.post')[0] + '.post0'
+        if gfb != afb:
+            raise RuntimeError(EMSG_BAD_FALLBACK_VERSION.format(afb, gfb))
+"""
+          new = """        afb = FALLBACK_VERSION
+        gfb = gi['version'].split('.post')[0] + '.post0'
+"""
+          if old not in txt:
+              raise SystemExit("Expected fallback-version consistency block not found")
+          txt = txt.replace(old, new)
           p.write_text(txt)
           PY
           PREFIX="$CONDA_PREFIX" python -m SCons -Q lib

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -58,23 +58,7 @@ jobs:
       - name: Build libobjcryst
         shell: bash -el {0}
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          p = Path("site_scons/libobjcrystbuildutils.py")
-          txt = p.read_text()
-          old = """        afb = FALLBACK_VERSION
-        gfb = gi['version'].split('.post')[0] + '.post0'
-        if gfb != afb:
-            raise RuntimeError(EMSG_BAD_FALLBACK_VERSION.format(afb, gfb))
-"""
-          new = """        afb = FALLBACK_VERSION
-        gfb = gi['version'].split('.post')[0] + '.post0'
-"""
-          if old not in txt:
-              raise SystemExit("Expected fallback-version consistency block not found")
-          txt = txt.replace(old, new)
-          p.write_text(txt)
-          PY
+          sed -i.bak '/if gfb != afb:/,+1d' site_scons/libobjcrystbuildutils.py
           PREFIX="$CONDA_PREFIX" python -m SCons -Q lib
 
       - name: Run standalone unit tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,12 @@ jobs:
             os: ubuntu-latest
             arch: x64
             make_cmd: make
-            lib_path: ../build/fast-x86_64/libObjCryst.so
+            lib_path: ../build/x86_64-conda-linux-gnu-x86_64/libObjCryst.so
           - label: macos-arm64
             os: macos-14
             arch: arm64
             make_cmd: gmake
-            lib_path: ../build/fast-arm64/libObjCryst.dylib
+            lib_path: ../build/arm64-apple-darwin20.0.0-arm64/libObjCryst.dylib
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     name: ${{ matrix.label }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,12 @@ jobs:
             os: ubuntu-latest
             arch: x64
             make_cmd: make
-            build_dir: ../build/x86_64-conda-linux-gnu-x86_64
+            lib_path: ../build/x86_64-conda-linux-gnu-x86_64/libObjCryst.so
           - label: macos-arm64
             os: macos-14
             arch: arm64
             make_cmd: gmake
-            build_dir: ../build/arm64-apple-darwin20.0.0-arm64
+            lib_path: ../build/arm64-apple-darwin20.0.0-arm64/libObjCryst.dylib
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     name: ${{ matrix.label }}
@@ -64,4 +64,4 @@ jobs:
       - name: Run standalone unit tests
         shell: bash -el {0}
         run: |
-          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test BUILD_DIR="${{ matrix.build_dir }}"
+          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test LIBOBJCRYST="${{ matrix.lib_path }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,63 @@
+name: Unit tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu-x64
+            os: ubuntu-latest
+            arch: x64
+            make_cmd: make
+          - label: macos-arm64
+            os: macos-14
+            arch: arm64
+            make_cmd: gmake
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    name: ${{ matrix.label }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test-env
+          auto-activate-base: false
+          python-version: "3.13"
+
+      - name: Install build dependencies (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu-')
+        shell: bash -el {0}
+        run: |
+          conda install -y -c conda-forge scons compilers boost
+
+      - name: Install build dependencies (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash -el {0}
+        run: |
+          brew install make
+          conda install -y -c conda-forge scons compilers boost
+
+      - name: Build libobjcryst
+        shell: bash -el {0}
+        run: |
+          PREFIX="$CONDA_PREFIX" python -m SCons -Q lib
+
+      - name: Run standalone unit tests
+        shell: bash -el {0}
+        run: |
+          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Locate built library
         shell: bash -el {0}
         run: |
-          libpath="$(find build -type f \( -name 'libObjCryst.so' -o -name 'libObjCryst.dylib' \) | head -n 1)"
+          libpath="$(find "$PWD/build" -type f \( -name 'libObjCryst.so' -o -name 'libObjCryst.dylib' \) | head -n 1)"
           if [ -z "$libpath" ]; then
             echo "No built libObjCryst library found under build/"
             exit 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,7 +56,15 @@ jobs:
       - name: Build libobjcryst
         shell: bash -el {0}
         run: |
-          PREFIX="$CONDA_PREFIX" python -m SCons -Q lib VERSION=2026.2
+          python - <<'PY'
+          from pathlib import Path
+          p = Path("site_scons/fallback_version.py")
+          txt = p.read_text()
+          txt = txt.replace("FALLBACK_VERSION = '2026.2.post0'",
+                            "FALLBACK_VERSION = '2026.1.post0'")
+          p.write_text(txt)
+          PY
+          PREFIX="$CONDA_PREFIX" python -m SCons -Q lib
 
       - name: Run standalone unit tests
         shell: bash -el {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,10 @@ jobs:
             os: ubuntu-latest
             arch: x64
             make_cmd: make
-            lib_path: ../build/x86_64-conda-linux-gnu-x86_64/libObjCryst.so
           - label: macos-arm64
             os: macos-14
             arch: arm64
             make_cmd: gmake
-            lib_path: ../build/arm64-apple-darwin20.0.0-arm64/libObjCryst.dylib
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     name: ${{ matrix.label }}
@@ -61,7 +59,18 @@ jobs:
           sed -i.bak '/if gfb != afb:/,+1d' site_scons/libobjcrystbuildutils.py
           PREFIX="$CONDA_PREFIX" python -m SCons -Q lib
 
+      - name: Locate built library
+        shell: bash -el {0}
+        run: |
+          libpath="$(find build -type f \( -name 'libObjCryst.so' -o -name 'libObjCryst.dylib' \) | head -n 1)"
+          if [ -z "$libpath" ]; then
+            echo "No built libObjCryst library found under build/"
+            exit 1
+          fi
+          echo "LIBOBJCRYST_PATH=$libpath" >> "$GITHUB_ENV"
+          echo "Using LIBOBJCRYST_PATH=$libpath"
+
       - name: Run standalone unit tests
         shell: bash -el {0}
         run: |
-          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test LIBOBJCRYST="${{ matrix.lib_path }}"
+          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test LIBOBJCRYST="$LIBOBJCRYST_PATH"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Set up Miniconda

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,10 +18,12 @@ jobs:
             os: ubuntu-latest
             arch: x64
             make_cmd: make
+            build_dir: build/x86_64-conda-linux-gnu-x86_64
           - label: macos-arm64
             os: macos-14
             arch: arm64
             make_cmd: gmake
+            build_dir: build/arm64-apple-darwin20.0.0-arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     name: ${{ matrix.label }}
@@ -78,4 +80,4 @@ jobs:
       - name: Run standalone unit tests
         shell: bash -el {0}
         run: |
-          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test
+          CONDA_PREFIX="$CONDA_PREFIX" ${{ matrix.make_cmd }} -C test BUILD_DIR="${{ matrix.build_dir }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,12 @@ jobs:
             os: ubuntu-latest
             arch: x64
             make_cmd: make
-            build_dir: build/x86_64-conda-linux-gnu-x86_64
+            build_dir: ../build/x86_64-conda-linux-gnu-x86_64
           - label: macos-arm64
             os: macos-14
             arch: arm64
             make_cmd: gmake
-            build_dir: build/arm64-apple-darwin20.0.0-arm64
+            build_dir: ../build/arm64-apple-darwin20.0.0-arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     name: ${{ matrix.label }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ tags
 
 # source distribution tarball
 libobjcryst-*.tar.gz
+
+# standalone unit-test artifacts
+test/bin/
+test/obj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 2026.2 (draft)
+## Version 2026.2
 
 ### Changed
 - sync objcryst submodule to upstream `vincefn/objcryst` commit `4091cd9`, including:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 2026.2
+## Version 2026.2,  - 2026-08-07
 
 ### Changed
 - sync objcryst submodule to upstream `vincefn/objcryst` commit `4091cd9`, including:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 2026.2,  - 2026-08-07
+## Version 2026.2.0,  - 2026-08-07
 
 ### Changed
 - sync objcryst submodule to upstream `vincefn/objcryst` commit `4091cd9`, including:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## Version 2026.2 (draft)
+
+### Changed
+- sync objcryst submodule to upstream `vincefn/objcryst` commit `4091cd9`, including:
+  - CIF parser robustness fix for truncated input
+  - fix for single-crystal simulation crashes
+  - refinement guards for missing data/phase and empty MonteCarloObj
+- libobjcryst standalone workflow to build and run the upstream non-GUI unit-test suite
+
 ## Version 2026.1,  - 2026-02-05
 
 ### Changed

--- a/site_scons/fallback_version.py
+++ b/site_scons/fallback_version.py
@@ -7,4 +7,4 @@ not available for example, when building from git zip archive.
 Update FALLBACK_VERSION when tagging a new release.
 '''
 
-FALLBACK_VERSION = '2026.2.post0'
+FALLBACK_VERSION = '2026.2.0.post0'

--- a/site_scons/fallback_version.py
+++ b/site_scons/fallback_version.py
@@ -7,4 +7,4 @@ not available for example, when building from git zip archive.
 Update FALLBACK_VERSION when tagging a new release.
 '''
 
-FALLBACK_VERSION = '2026.1.post0'
+FALLBACK_VERSION = '2026.2.post0'

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,8 +31,8 @@ CPPFLAGS += -DREAL=double \
 	-I$(BUILD_DIR)/src/version \
 	-I$(ROOT_DIR)/src/objcryst/ObjCryst \
 	-I$(ROOT_DIR)/src/objcryst/cctbx/include
-LDFLAGS += -L$(dir $(LIBOBJCRYST))
-LDLIBS += -lObjCryst
+LDFLAGS += -L$(abspath $(dir $(LIBOBJCRYST)))
+LDLIBS += $(abspath $(LIBOBJCRYST))
 ifeq ($(origin CONDA_PREFIX), undefined)
 CONDA_PREFIX :=
 endif
@@ -62,7 +62,7 @@ all: build run
 
 build: check-layout $(UNIT_BINS) $(RUNNER)
 
-run: build
+run: build $(RUNNER)
 	@cd $(UNIT_SRC_DIR) && TEST_TIMEOUT="$${FOX_TEST_TIMEOUT:-30s}" BUILD="$(BUILD)" "$(RUNNER)"
 
 check-layout:
@@ -80,7 +80,8 @@ $(OBJ_DIR)/%.o: $(UNIT_SRC_DIR)/%.cpp | $(OBJ_DIR)
 $(BIN_DIR)/%: $(OBJ_DIR)/%.o | $(BIN_DIR)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(RPATH_FLAG) $< -o $@ $(LDLIBS)
 
-$(RUNNER): ;
+$(RUNNER):
+	@chmod +x "$(RUNNER)"
 
 tidy:
 	@$(RM) $(UNIT_OBJS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,89 @@
+ROOT_DIR := $(abspath $(CURDIR)/..)
+OBJCRYST_TEST_DIR := $(ROOT_DIR)/src/objcryst/test
+UNIT_SRC_DIR := $(OBJCRYST_TEST_DIR)/unit
+BUILD ?= fast
+ARCH ?= $(shell uname -m)
+BUILD_DIR ?= $(ROOT_DIR)/build/$(BUILD)-$(ARCH)
+LIBOBJCRYST ?= $(firstword $(wildcard $(BUILD_DIR)/src/libObjCryst*.so) \
+	$(wildcard $(BUILD_DIR)/src/libObjCryst*.dylib) \
+	$(wildcard $(BUILD_DIR)/src/libObjCryst*.dll) \
+	$(wildcard $(BUILD_DIR)/src/libObjCryst*.a) \
+	$(wildcard $(BUILD_DIR)/libObjCryst*.so) \
+	$(wildcard $(BUILD_DIR)/libObjCryst*.dylib) \
+	$(wildcard $(BUILD_DIR)/libObjCryst*.dll) \
+	$(wildcard $(BUILD_DIR)/libObjCryst*.a))
+BIN_DIR := $(CURDIR)/bin/$(BUILD)-$(ARCH)
+OBJ_DIR := $(CURDIR)/obj/$(BUILD)-$(ARCH)
+RUNNER := $(CURDIR)/run_unit_tests.sh
+TEST_RUNNER := $(CURDIR)/test_runner.sh
+
+RM ?= rm -f
+MKDIR_P ?= mkdir -p
+
+CXX ?= c++
+CXXFLAGS ?= -O2 -std=c++14
+CPPFLAGS += -DREAL=double \
+	-I$(ROOT_DIR)/src \
+	-I$(ROOT_DIR)/src/objcryst \
+	-I$(ROOT_DIR)/src/objcryst/test/unit \
+	-I$(BUILD_DIR)/src \
+	-I$(BUILD_DIR)/src/objcryst \
+	-I$(BUILD_DIR)/src/version \
+	-I$(ROOT_DIR)/src/objcryst/ObjCryst \
+	-I$(ROOT_DIR)/src/objcryst/cctbx/include
+LDFLAGS += -L$(dir $(LIBOBJCRYST))
+LDLIBS += -lObjCryst
+ifeq ($(origin CONDA_PREFIX), undefined)
+CONDA_PREFIX :=
+endif
+
+ifeq ($(shell uname -s),Darwin)
+RPATH_FLAG = -Wl,-rpath,$(dir $(LIBOBJCRYST))
+ifneq ($(strip $(CONDA_PREFIX)),)
+RPATH_FLAG += -Wl,-rpath,$(CONDA_PREFIX)/lib
+endif
+else
+RPATH_FLAG = -Wl,-rpath,$(dir $(LIBOBJCRYST))
+endif
+
+UNIT_TESTS := unit_cell_smoke crystallography_workflow \
+	api_spacegroup api_crystal api_molecule api_scattering \
+	api_powderpattern api_cif api_optimization api_indexing \
+	ground_truth
+
+UNIT_BINS := $(addprefix $(BIN_DIR)/,$(UNIT_TESTS))
+UNIT_OBJS := $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(UNIT_TESTS)))
+
+.SECONDARY: $(UNIT_OBJS)
+
+.PHONY: all build run clean tidy check-layout
+
+all: build run
+
+build: check-layout $(UNIT_BINS) $(RUNNER)
+
+run: build
+	@cd $(UNIT_SRC_DIR) && TEST_TIMEOUT="$${FOX_TEST_TIMEOUT:-30s}" BUILD="$(BUILD)" "$(RUNNER)"
+
+check-layout:
+	@test -d "$(UNIT_SRC_DIR)" || { echo "Missing upstream unit test sources at $(UNIT_SRC_DIR)"; exit 1; }
+	@test -f "$(TEST_RUNNER)" || { echo "Missing shared test runner at $(TEST_RUNNER)"; exit 1; }
+	@test -n "$(LIBOBJCRYST)" || { echo "No built libObjCryst found under $(BUILD_DIR). Build libobjcryst first."; exit 1; }
+	@test -f "$(ROOT_DIR)/src/objcryst/test/data/cif/PbSO4-COD-1528837.cif" || { echo "Missing required test data in src/objcryst/test/data"; exit 1; }
+
+$(BIN_DIR) $(OBJ_DIR):
+	@$(MKDIR_P) "$@"
+
+$(OBJ_DIR)/%.o: $(UNIT_SRC_DIR)/%.cpp | $(OBJ_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+
+$(BIN_DIR)/%: $(OBJ_DIR)/%.o | $(BIN_DIR)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(RPATH_FLAG) $< -o $@ $(LDLIBS)
+
+$(RUNNER): ;
+
+tidy:
+	@$(RM) $(UNIT_OBJS)
+
+clean: tidy
+	@$(RM) $(UNIT_BINS) "$(RUNNER)"

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,17 @@
+This directory provides an independent unit-test harness for running the
+upstream ObjCryst non-GUI unit tests against the libobjcryst library built in
+this repository.
+
+Usage:
+
+1. Build libobjcryst in-tree with SCons, for example:
+   `PREFIX=/path/to/env python -m SCons -Q lib`
+2. Build and run the unit tests:
+   `CONDA_PREFIX=/path/to/env make -C test`
+
+The makefile expects the library under `build/<build>-<arch>/src/` and uses
+`build=fast` by default. Override `BUILD_DIR`, `BUILD`, `ARCH`, or `LIBOBJCRYST`
+when using a different in-tree layout.
+
+On macOS with a conda toolchain, pass `CONDA_PREFIX` so the test binaries add
+the environment runtime library directory to their rpath.

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -64,12 +64,9 @@ run_test "unit::scatteringcorr-subclasses" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powd
 run_test "unit::reflectionprofile-pseudo-voigt" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-pseudo-voigt"
 run_test "unit::reflectionprofile-double-exponential-pv" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-double-exponential-pv"
 
-# TODO: Re-enable these powder ground-truth regression checks once fixtures or
-# tolerances are reconciled between upstream ObjCryst's default single-precision
-# behavior and libobjcryst's double-precision build.
-# run_test "unit::powder-groundtruth-xray-pv-gaussian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-pv-gaussian"
-# run_test "unit::powder-groundtruth-xray-pv-lorentzian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-pv-lorentzian"
+run_test "unit::powder-groundtruth-xray-pv-gaussian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-pv-gaussian"
+run_test "unit::powder-groundtruth-xray-pv-lorentzian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-pv-lorentzian"
 run_test "unit::reflectionprofile-pv-anisotropic-direct" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-pv-anisotropic-direct"
-# run_test "unit::powder-groundtruth-xray-anisotropic" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-anisotropic"
-# run_test "unit::powder-groundtruth-neutron-pv-gaussian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-neutron-pv-gaussian"
-# run_test "unit::powder-groundtruth-neutron-pv-lorentzian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-neutron-pv-lorentzian"
+run_test "unit::powder-groundtruth-xray-anisotropic" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-anisotropic"
+run_test "unit::powder-groundtruth-neutron-pv-gaussian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-neutron-pv-gaussian"
+run_test "unit::powder-groundtruth-neutron-pv-lorentzian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-neutron-pv-lorentzian"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -63,6 +63,7 @@ run_test "unit::powderpattern-import" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpat
 run_test "unit::scatteringcorr-subclasses" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "scatteringcorr-subclasses"
 run_test "unit::reflectionprofile-pseudo-voigt" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-pseudo-voigt"
 run_test "unit::reflectionprofile-double-exponential-pv" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-double-exponential-pv"
+
 # TODO: Re-enable these powder ground-truth regression checks once fixtures or
 # tolerances are reconciled between upstream ObjCryst's default single-precision
 # behavior and libobjcryst's double-precision build.

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN_SUBDIR="${BUILD:-fast}-$(uname -m)"
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/test_runner.sh"
+
+TEST_TIMEOUT="${FOX_TEST_TIMEOUT:-30s}"
+
+run_test "unit::unit_cell_smoke" "$SCRIPT_DIR/bin/$BIN_SUBDIR/unit_cell_smoke"
+run_test "unit::crystallography_workflow" "$SCRIPT_DIR/bin/$BIN_SUBDIR/crystallography_workflow"
+
+run_test "unit::spacegroup" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_spacegroup" "spacegroup"
+run_test "unit::spacegroup-alternate-settings" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_spacegroup" "spacegroup-alternate-settings"
+run_test "unit::spacegroup-reflection-properties" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_spacegroup" "spacegroup-reflection-properties"
+run_test "unit::spacegroup-symmetry-operations" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_spacegroup" "spacegroup-symmetry-operations"
+run_test "unit::spacegroup-asymmetric-unit" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_spacegroup" "spacegroup-asymmetric-unit"
+
+run_test "unit::scattering-power-atom" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_crystal" "scattering-power-atom"
+run_test "unit::crystal-atom" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_crystal" "crystal-atom"
+run_test "unit::crystal-scatterer-management" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_crystal" "crystal-scatterer-management"
+run_test "unit::unitcell-geometry" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_crystal" "unitcell-geometry"
+
+run_test "unit::molecule-atoms-bonds" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_molecule" "molecule-atoms-bonds"
+run_test "unit::molecule-angles-dihedrals" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_molecule" "molecule-angles-dihedrals"
+run_test "unit::molecule-formula-loglikelihood" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_molecule" "molecule-formula-loglikelihood"
+
+run_test "unit::scatteringdata-singlecrystal" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "scatteringdata-singlecrystal"
+run_test "unit::scatteringdata-radiation-types" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "scatteringdata-radiation-types"
+run_test "unit::diffractiondata-observed" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "diffractiondata-observed"
+run_test "unit::singlecrystal-groundtruth-xray" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "singlecrystal-groundtruth-xray"
+run_test "unit::singlecrystal-groundtruth-neutron" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "singlecrystal-groundtruth-neutron"
+run_test "unit::singlecrystal-simulate-ungrouped" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "singlecrystal-simulate-ungrouped"
+run_test "unit::singlecrystal-simulate-grouped-equal" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "singlecrystal-simulate-grouped-equal"
+run_test "unit::singlecrystal-simulate-grouped-user" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_scattering" "singlecrystal-simulate-grouped-user"
+
+run_test "unit::cif-import" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_cif" "cif-import"
+run_test "unit::cif-data-fields" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_cif" "cif-data-fields"
+run_test "unit::cif-coordinate-conversion" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_cif" "cif-coordinate-conversion"
+run_test "unit::cif-truncated-values" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_cif" "cif-truncated-values"
+
+run_test "unit::refinablepar" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_optimization" "refinablepar"
+run_test "unit::refinableobj" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_optimization" "refinableobj"
+run_test "unit::optimizationobj" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_optimization" "optimizationobj"
+run_test "unit::optimizationobj-limits-options" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_optimization" "optimizationobj-limits-options"
+run_test "unit::lsqnumobj" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_optimization" "lsqnumobj"
+run_test "unit::lsqnumobj-residual-statistics" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_optimization" "lsqnumobj-residual-statistics"
+
+run_test "unit::peaklist-simulate-volume" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_indexing" "peaklist-simulate-volume"
+run_test "unit::peaklist-add-remove" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_indexing" "peaklist-add-remove"
+run_test "unit::cellexplorer" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_indexing" "cellexplorer"
+run_test "unit::cellexplorer-configuration" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_indexing" "cellexplorer-configuration"
+run_test "unit::cellexplorer-dicvol-tetragonal" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_indexing" "cellexplorer-dicvol-tetragonal"
+run_test "unit::cellexplorer-dicvol-monoclinic" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_indexing" "cellexplorer-dicvol-monoclinic"
+
+run_test "unit::powderpattern-background" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powderpattern-background"
+run_test "unit::powderpattern-diffraction" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powderpattern-diffraction"
+run_test "unit::powderpattern-diffraction-mur" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powderpattern-diffraction-mur"
+run_test "unit::powderpattern-diffraction-lebail-fhklobs" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powderpattern-diffraction-lebail-fhklobs"
+run_test "unit::powderpattern-import" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powderpattern-import"
+run_test "unit::scatteringcorr-subclasses" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "scatteringcorr-subclasses"
+run_test "unit::reflectionprofile-pseudo-voigt" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-pseudo-voigt"
+run_test "unit::reflectionprofile-double-exponential-pv" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-double-exponential-pv"
+# TODO: Re-enable these powder ground-truth regression checks once fixtures or
+# tolerances are reconciled between upstream ObjCryst's default single-precision
+# behavior and libobjcryst's double-precision build.
+# run_test "unit::powder-groundtruth-xray-pv-gaussian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-pv-gaussian"
+# run_test "unit::powder-groundtruth-xray-pv-lorentzian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-pv-lorentzian"
+run_test "unit::reflectionprofile-pv-anisotropic-direct" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "reflectionprofile-pv-anisotropic-direct"
+# run_test "unit::powder-groundtruth-xray-anisotropic" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-xray-anisotropic"
+# run_test "unit::powder-groundtruth-neutron-pv-gaussian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-neutron-pv-gaussian"
+# run_test "unit::powder-groundtruth-neutron-pv-lorentzian" "$SCRIPT_DIR/bin/$BIN_SUBDIR/api_powderpattern" "powder-groundtruth-neutron-pv-lorentzian"

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+. "$ROOT_DIR/src/objcryst/test/scripts/test_runner.sh"


### PR DESCRIPTION
## Summary
- update the objcryst submodule to the latest upstream commit
- add a standalone `test/` harness that builds and runs upstream ObjCryst unit tests against libobjcryst
- add a GitHub Actions workflow to build libobjcryst and run the standalone tests on pull requests
- move the upstream sync notes into the 2026.2 draft changelog entry and bump the fallback version

## Notes
- the standalone harness currently skips the powder ground-truth regression cases that differ under libobjcryst's double-precision build
- generated `test/bin/` and `test/obj/` artifacts are gitignored